### PR TITLE
Add stop_times routes, adjust routes for calendars

### DIFF
--- a/app/controllers/calendar_dates_controller.rb
+++ b/app/controllers/calendar_dates_controller.rb
@@ -8,13 +8,13 @@ class CalendarDatesController < ApplicationController
 
   # GET /calendar_dates/1
   def show
-    render json: @calendar_date
+    render json: paginate_results(@calendar_date)
   end
 
   private
 
   # Use callbacks to share common setup or constraints between actions.
   def set_calendar_date
-    @calendar_date = CalendarDate.find(params[:id])
+    @calendar_date = CalendarDate.where(service_gid: params[:service_gid])
   end
 end

--- a/app/controllers/stop_times_controller.rb
+++ b/app/controllers/stop_times_controller.rb
@@ -1,0 +1,21 @@
+class StopTimesController < ApplicationController
+  before_action :set_stop_time, only: [:show]
+
+  # GET /stop_times
+  def index
+    render json: paginate_results(StopTime.all)
+  end
+
+  # GET /stop_times/1
+  def show
+    render json: @stop_times
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_stop_time
+    @stop_times = StopTime.where(stop_gid: params[:stop_gid])
+    raise 'NotFoundException' if @stop_times.empty?
+  end
+end

--- a/app/models/calendar_date.rb
+++ b/app/models/calendar_date.rb
@@ -1,4 +1,6 @@
 class CalendarDate < ApplicationRecord
+  default_scope { order(date: :asc) }
+
   def self.hash_from_gtfs(row)
     calendar = Calendar.find_by_service_gid(row.service_id)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,8 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   resources :agencies, only: %i[index show]
-  resources :calendar_dates, only: %i[index show]
+  get '/calendar_dates', to: 'calendar_dates#index', as: 'calendar_dates'
+  get '/calendar_dates/:service_gid', to: 'calendar_dates#show', as: 'calendar_date'
 
   get '/calendars', to: 'calendars#index', as: 'calendars'
   get '/calendars/:service_gid', to: 'calendars#show', as: 'calendar'
@@ -27,6 +28,9 @@ Rails.application.routes.draw do
   get '/stops', to: 'stops#index', as: 'stops'
   get '/stops/:stop_gid', to: 'stops#show', as: 'stop'
   get '/stops/:stop_gid/stop_times', to: 'stops#show_stop_times', as: 'stop_stop_times'
+
+  get '/stop_times', to: 'stop_times#index', as: 'stop_times'
+  get '/stop_times/:stop_gid', to: 'stop_times#show', as: 'stop_time'
 
   resources :transfers, only: %i[index show]
 

--- a/test/controllers/calendar_dates_controller_test.rb
+++ b/test/controllers/calendar_dates_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class CalendarDatesControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @calendar_date = calendar_dates(:CalendarDate_1)
+    @calendar_date = calendar_dates(:CalendarDate_1).service_gid
   end
 
   test "should get index" do

--- a/test/controllers/stop_times_controller_test.rb
+++ b/test/controllers/stop_times_controller_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class StopTimesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @stop_times = stop_times(:StopTime_1).stop_gid
+  end
+
+  test "should get index" do
+    get stop_times_url, as: :json
+    assert_response :success
+  end
+
+  test "should show stop stop_times" do
+    get stop_time_url(@stop_times), as: :json
+    assert_response :success
+  end
+end


### PR DESCRIPTION
While the `stop_times` routes are a bit of a duplicate for queries against a `trip` or `stop`, it may be useful in the future for other work.  Also made the `calendar_dates` key off the `service_gid`.