### PR TITLE
Handle over 24 hour timestamp

### DIFF
--- a/app/models/stop_time.rb
+++ b/app/models/stop_time.rb
@@ -18,8 +18,8 @@ class StopTime < ApplicationRecord
     record = {}
     record[:trip_gid] = row.trip_id
     record[:trip_id] = Trip.find_by_trip_gid(row.trip_id).id
-    record[:arrival_time] = row.arrival_time
-    record[:departure_time] = row.departure_time
+    record[:arrival_time] = self.format_time_over_24(row.arrival_time)
+    record[:departure_time] = self.format_time_over_24(row.departure_time)
     record[:stop_gid] = row.stop_id
     record[:stop_id] = Stop.find_by_stop_gid(row.stop_id).id
     record[:stop_sequence] = row.stop_sequence
@@ -28,6 +28,16 @@ class StopTime < ApplicationRecord
     record[:drop_off_type] = row.drop_off_type
     record[:shape_dist_traveled] = row.shape_dist_traveled
     # record[:timepoint] = row.timepoint
+
     record
+  end
+
+  def self.format_time_over_24(time)
+    hours, minutes, seconds = time.split(':').map(&:to_f)
+    hours %= 24
+    minutes %= 60
+    seconds %= 60
+    time = Time.new(0, 1, 1, hours, minutes, seconds, 0)
+    time.strftime('%H:%M:%S')
   end
 end


### PR DESCRIPTION
The new schedules have times like 24:01:01 to indicate midnight + 01:01. This PR fixes that in the `stop_times` table. The sequence still indicates what time things are getting where.